### PR TITLE
細かいバグと挙動を修正

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -11,6 +11,28 @@ SLACK_OAUTH_ACCESS_TOKEN = ENV['SLACK_OAUTH_ACCESS_TOKEN']
 ESA_ACCESS_TOKEN = ENV['ESA_ACCESS_TOKEN']
 ESA_TEAM_NAME = ENV['ESA_TEAM_NAME']
 IMAGE_BUFFER_DIR = "images"
+ESA_DEFAULT_EMOJIS = [
+  'bowtie',
+  'squirrel',
+  'neckbeard',
+  'metal',
+  'fu',
+  'feelsgood',
+  'finnadie',
+  'goberserk',
+  'godmode',
+  'hurtrealbad',
+  'rage1',
+  'rage2',
+  'rage3',
+  'rage4',
+  'suspect',
+  'trollface',
+  'octocat',
+  'biohazard',
+  'esa',
+  'unicorn'
+]
 
 if SLACK_OAUTH_ACCESS_TOKEN.nil? || ESA_ACCESS_TOKEN.nil? || ESA_TEAM_NAME.nil?
   puts "[ERROR]: Require ENV['SLACK_OAUTH_ACCESS_TOKEN']." if SLACK_OAUTH_ACCESS_TOKEN.nil?
@@ -37,7 +59,7 @@ all_emojis = slack.emojis
 existing_emojis = esa_emoji_client.get_all_custom_emojis
 
 ## すでにesaに登録されている絵文字は対象外にする
-new_emojis = all_emojis.reject { |emoji| existing_emojis.include?(emoji) }
+new_emojis = all_emojis.reject { |emoji| existing_emojis.include?(emoji) || ESA_DEFAULT_EMOJIS.include?(emoji.name) }
 alias_emojis, emojis = new_emojis.partition(&:alias?)
 
 ## SlackからDLした絵文字画像を保存するフォルダを準備

--- a/lib/esa_emoji_client.rb
+++ b/lib/esa_emoji_client.rb
@@ -120,7 +120,7 @@ class EsaEmojiClient
 
   private
   def allowed_name?(name)
-    return (/^[0-9a-zA-Z\-\_]+$/ =~ name)
+    return (/^[0-9a-z\-\_]+$/ =~ name)
   end
 
   def allowed_extension?(extension)

--- a/lib/esa_emoji_client.rb
+++ b/lib/esa_emoji_client.rb
@@ -77,6 +77,10 @@ class EsaEmojiClient
       puts "[ERROR] 絵文字の名前( :#{name}: ) には小文字の英数字と、アンダースコア(_)、ハイフン(-)のみが使用できます。"
       return
     end
+    unless allowed_name?(target_name)
+      puts "[ERROR] 絵文字の名前( :#{target_name}: ) には小文字の英数字と、アンダースコア(_)、ハイフン(-)のみが使用できます。"
+      return
+    end
 
     if @dry_run
       puts "[INFO] :#{name}: を :#{target_name}: のエイリアスとして登録しました。"
@@ -116,7 +120,7 @@ class EsaEmojiClient
 
   private
   def allowed_name?(name)
-    return (/[a-z\d\-_]+/ =~ name)
+    return (/^[0-9a-zA-Z\-\_]+$/ =~ name)
   end
 
   def allowed_extension?(extension)


### PR DESCRIPTION
- aliasのターゲットになるEmojiの名前もesaの絵文字ルールに従わない場合はスキップする
- esaにデフォルトで登録されているEmojiはスキップする